### PR TITLE
Update EEx identifiers to match vscode-elixir-ls

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,11 +19,11 @@
     "contributes": {
         "snippets": [
             {
-                "language": "Eex",
+                "language": "EEx",
                 "path": "./snippets/snippets.json"
             },
             {
-                "language": "HTML (Eex)",
+                "language": "HTML (EEx)",
                 "path": "./snippets/snippets.json"
             }
         ]

--- a/package.json
+++ b/package.json
@@ -25,6 +25,14 @@
             {
                 "language": "HTML (EEx)",
                 "path": "./snippets/snippets.json"
+            },
+            {
+                "language": "Eex",
+                "path": "./snippets/snippets.json"
+            },
+            {
+                "language": "HTML (Eex)",
+                "path": "./snippets/snippets.json"
             }
         ]
     }


### PR DESCRIPTION
The [VS Code ElixirLS extension](https://github.com/JakeBecker/vscode-elixir-ls/) recently updated to use `EEx` and `HTML (EEx)` (with a capitalized second `E`) in its grammar identifiers. As a result, the snippets contained in this package became unavailable in EEx files. This change updates the snippet contribution to match the new identifiers in that package.

Note that, if this change is accepted, users of the [no-longer-maintained](https://github.com/fr1zle/vscode-elixir/issues/128#issuecomment-478668010) [VS Code Elixir](https://github.com/fr1zle/vscode-elixir/) extension will face the same issue, in reverse. Relevant communication might be advisable.

See https://github.com/JakeBecker/vscode-elixir-ls/issues/134 for more information.