### PR TITLE
New exec block snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Below is a list of all available snippets.
 | Trigger  | Content |
 | -------: | ------- |
 | `e=`     | render block `<%= %>`|
-| `e-`     | exec block `<%- %>`|
+| `ee`     | exec block `<% %>`| 
 | `e#`     | comment `<%# %>`|
 | `end`    | end tag `<% end %>`|
 | `lt`     | link `<%= link \"${1:text}\", to: ${2:url} %>`|

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -5,9 +5,9 @@
     "description": "<%= %> render block"
   },
   "eex_exec_block": {
-    "prefix": "e-",
-    "body": ["<%- $1 %>"],
-    "description": "<%- %> exec block"
+    "prefix": "ee",
+    "body": ["<% $1 %>"],
+    "description": "<% %> exec block"
   },
   "eex_comment_block": {
     "prefix": "e#",


### PR DESCRIPTION
First of all, I want to thank you @stefanjarina for this great extension you’ve created. Your extension has improved radically the way I work with Eex files!  😄 

In this PR, I propose to change the “exec block” snippet. 

Instead of writing `e-`, I propose to write `ee` (this is what I do with a snippet I run along with your library).
Also, I removed the dash sign because it is useless and because we don’t write an “exec block” with it (c.f. [the documentation](https://hexdocs.pm/eex/EEx.html#module-tags) )

I think these small changes may improve the productivity of Elixir developers.

Also, please note that I haven’t added a Changelog. 

Thanks 